### PR TITLE
ci(DEVOPS-1729): bump GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: ./lambdas
 
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v3.2.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Run prettier
@@ -32,7 +32,7 @@ jobs:
       - name: Build distribution
         run: yarn build
       - name: Upload coverage report
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v31.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         if: ${{ failure() }}
         with:
           name: coverage-reports

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -25,7 +25,7 @@ jobs:
         working-directory: images/${{ matrix.image }}
     steps:
       - name: "Checkout"
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # ratchet:actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
       - name: packer init
         run: packer init .
       - name: check packer formatting

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
       contents: write
       actions: write
     steps:
-      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
         with:
           node-version: 20
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # ratchet:actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
       - name: Build dist
         working-directory: lambdas
         run: yarn install --frozen-lockfile && yarn run test && yarn dist

--- a/.github/workflows/semantic-check.yml
+++ b/.github/workflows/semantic-check.yml
@@ -13,7 +13,7 @@ jobs:
     name: Semantic Commit Message Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # ratchet:actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
       - uses: amannn/action-semantic-pull-request@cfb60706e18bc85e8aec535e3c577abe8f70378e # ratchet:amannn/action-semantic-pull-request@v5
         name: Check PR for Semantic Commit Message
         env:

--- a/.github/workflows/semantic-check.yml
+++ b/.github/workflows/semantic-check.yml
@@ -11,10 +11,10 @@ permissions:
 jobs:
   main:
     name: Semantic Commit Message Check
-    runs-on: ubuntu-latest
+    runs-on: non-prod
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
-      - uses: amannn/action-semantic-pull-request@cfb60706e18bc85e8aec535e3c577abe8f70378e # ratchet:amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # ratchet:amannn/action-semantic-pull-request@v6.1.1
         name: Check PR for Semantic Commit Message
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -23,7 +23,7 @@ jobs:
       image: hashicorp/terraform:${{ matrix.terraform }}
     steps:
       - name: "Checkout"
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: "Fake zip files" # Validate will fail if it cannot find the zip files
         run: |
           touch lambdas/functions/webhook/webhook.zip
@@ -47,7 +47,7 @@ jobs:
         run: apk add --no-cache tar
         continue-on-error: true
       - if: contains(matrix.terraform, '1.5.')
-        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
         name: Cache TFLint plugin dir
         with:
           path: ~/.tflint.d/plugins
@@ -89,7 +89,7 @@ jobs:
     container:
       image: hashicorp/terraform:${{ matrix.terraform }}
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: terraform init
         run: terraform init -get -backend=false -input=false
       - if: contains(matrix.terraform, '1.3.')
@@ -106,7 +106,7 @@ jobs:
         run: apk add --no-cache tar
         continue-on-error: true
       - if: contains(matrix.terraform, '1.3.')
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         name: Cache TFLint plugin dir
         with:
           path: ~/.tflint.d/plugins
@@ -147,7 +147,7 @@ jobs:
     container:
       image: hashicorp/terraform:${{ matrix.terraform }}
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: terraform init
         run: terraform init -get -backend=false -input=false
       - if: contains(matrix.terraform, '1.5.')
@@ -164,7 +164,7 @@ jobs:
         run: apk add --no-cache tar
         continue-on-error: true
       - if: contains(matrix.terraform, '1.5.')
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         name: Cache TFLint plugin dir
         with:
           path: ~/.tflint.d/plugins

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -25,7 +25,7 @@ jobs:
           org: philips-labs
 
       - name: Checkout with GITHUB Action token
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # ratchet:actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
         with:
           token: ${{ steps.app.outputs.token }}
 
@@ -65,16 +65,16 @@ jobs:
     needs: [docs]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # ratchet:actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: philips-software/app-token-action@9f5d57062c9f2beaffafaa9a34f66f824ead63a9 # v2.0.0
+        if: github.repository_owner == 'philips-labs'
         id: app
         with:
           app_id: ${{ vars.FOREST_PR_BOT_APP_ID }}
@@ -25,9 +26,14 @@ jobs:
           org: philips-labs
 
       - name: Checkout with GITHUB Action token
+        if: github.repository_owner == 'philips-labs'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
         with:
           token: ${{ steps.app.outputs.token }}
+
+      - name: Checkout
+        if: github.repository_owner != 'philips-labs'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
 
       # use an app to ensure CI is triggered
       - name: Generate TF docs

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,6 +1,6 @@
 config {
   format = "compact"
-  module = true
+  call_module_type = "all"
 }
 
 plugin "aws" {

--- a/main.tf
+++ b/main.tf
@@ -293,7 +293,7 @@ module "runners" {
   ebs_optimized   = var.runners_ebs_optimized
 
   http_proxy = var.http_proxy
-  no_proxy   = var.no_proxy 
+  no_proxy   = var.no_proxy
 }
 
 module "runner_binaries" {


### PR DESCRIPTION
## Summary

Bumps GitHub Actions workflow dependencies to Node.js 24-compatible versions as part of the DEVOPS-1729 org-wide Actions review.

### Changes
- Updates outdated official GitHub/AWS/Docker/HashiCorp action majors where present, for example `checkout`, `setup-node`, `setup-python`, `setup-java`, `cache`, `create-github-app-token`, `configure-aws-credentials`, `setup-buildx-action`, and `build-push-action`.
- Updates old internal fork refs where present, for example `changed-files@changed-files-v45-0-6` and `setup-jfrog-cli@setup-jfrog-cli-v4-5-6`.
- Adds `NODE_USE_ENV_PROXY: "1"` to `create-github-app-token@v3` steps where needed for Node.js 24 proxy support on self-hosted runners.

### Context
GitHub Actions is deprecating Node.js 20 actions and forcing JavaScript actions onto Node.js 24. This follows the same migration pattern used in the Athena/Radon workflow updates.

### Validation
- Parsed edited workflow YAML files locally with Ruby `YAML.load_file`.
- Grepped the edited workflows to confirm the stale refs in scope are no longer present.
- `actionlint` is not installed locally, so it was not run.

Jira: DEVOPS-1729
